### PR TITLE
Fix some pom depreciation

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>loom-api</artifactId>
-    <version>${parent.version}</version>
+    <version>${project.parent.version}</version>
 
     <name>Loom API</name>
     <url>https://loomdev.org/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <minecraft.version>${version}</minecraft.version>
-        <api.version>${version}</api.version>
+        <minecraft.version>${project.version}</minecraft.version>
+        <api.version>${project.version}</api.version>
     </properties>
 
     <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>loom-server</artifactId>
-    <version>${parent.version}</version>
+    <version>${project.parent.version}</version>
 
     <dependencies>
         <!-- Server dependencies -->


### PR DESCRIPTION
This fixes some pom depreciation in cases using `${version}` and `${parent.version}` replacing them with `${project.version}` and `${project.parent.version}`.

There is still a warning while building:
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.loomdev:loom-api:jar:20w51a
[WARNING] 'version' contains an expression but should be a constant. @ org.loomdev:loom-api:${project.parent.version}, /home/ben/dev/Loom/api/pom.xml, line 13, column 14
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.loomdev:loom-server:jar:20w51a
[WARNING] 'version' contains an expression but should be a constant. @ org.loomdev:loom-server:${project.parent.version}, /home/ben/dev/Loom/server/pom.xml, line 14, column 14
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```
This warning is due to the api/server version being set to `${project.parent.version}` making it possibly "unstable". To remove the warning the versions would have to be hard set. That would make updates have more unnecessary steps, so its probably not worth it.