### PR TITLE
Add command completion support and fix possible copyright issue

### DIFF
--- a/server/patches/server/dedicated/DedicatedServer.patch
+++ b/server/patches/server/dedicated/DedicatedServer.patch
@@ -11,7 +11,30 @@
          this.settings = dedicatedserversettings;
          this.rconConsoleSource = new RconConsoleSource(this);
          this.textFilterClient = null;
-@@ -170,6 +170,7 @@
+@@ -84,7 +84,10 @@
+     public boolean initServer() throws IOException {
+         Thread thread = new Thread("Server console handler") {
+             public void run() {
+-                BufferedReader bufferedreader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
++                // Loom start :: Terminal console appender
++                new org.loomdev.loom.LoomConsole(DedicatedServer.this).start();
++
++                /* BufferedReader bufferedreader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+ 
+                 String s;
+ 
+@@ -94,8 +97,9 @@
+                     }
+                 } catch (IOException ioexception) {
+                     DedicatedServer.LOGGER.error("Exception handling console input", ioexception);
+-                }
++                } */
+ 
++                // Loom end
+             }
+         };
+ 
+@@ -170,6 +174,7 @@
              GameProfileCache.setUsesAuthentication(this.usesAuthentication());
              DedicatedServer.LOGGER.info("Preparing level \"{}\"", this.getLevelIdName());
              this.loadLevel();
@@ -19,7 +42,7 @@
              long j = Util.getNanos() - i;
              String s = String.format(Locale.ROOT, "%.3fs", (double) j / 1.0E9D);
  
-@@ -553,7 +554,9 @@
+@@ -553,7 +558,9 @@
          return this.settings.getProperties().forceGameMode ? this.worldData.getGameType() : null;
      }
  

--- a/server/src/main/java/org/loomdev/loom/LoomConsole.java
+++ b/server/src/main/java/org/loomdev/loom/LoomConsole.java
@@ -1,0 +1,76 @@
+package org.loomdev.loom;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.Completer;
+import org.jline.reader.ParsedLine;
+import org.jline.reader.Candidate;
+import net.minecrell.terminalconsole.SimpleTerminalConsole;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.commands.CommandSourceStack;
+import com.mojang.brigadier.ParseResults;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.Suggestions;
+
+import java.util.List;
+import java.nio.file.Paths;
+
+public class LoomConsole extends SimpleTerminalConsole {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private DedicatedServer server;
+
+    public LoomConsole(DedicatedServer server) {
+        this.server = server;
+    }
+
+    @Override
+    protected LineReader buildReader(LineReaderBuilder builder) {
+        return super.buildReader(builder
+                .appName("Server")
+                .variable(LineReader.HISTORY_FILE, Paths.get(".command_history"))
+                .completer(new CommandCompleter())
+        );
+    }
+
+    @Override
+    protected boolean isRunning() {
+        return server.isRunning() && !server.isStopped();
+    }
+
+    @Override
+    protected void runCommand(String command) {
+        server.handleConsoleInput(command, server.createCommandSourceStack());
+    }
+
+    @Override
+    protected void shutdown() {
+        server.halt(false);
+    }
+
+    public class CommandCompleter implements Completer {
+
+        @Override
+        public void complete(LineReader reader, ParsedLine line, List<Candidate> candidates) {
+            StringReader stringReader = new StringReader(line.line());
+
+            try {
+                ParseResults<CommandSourceStack> results = server.getCommands().getDispatcher().parse(stringReader, server.createCommandSourceStack());
+                Suggestions suggestions = server.getCommands().getDispatcher().getCompletionSuggestions(results).get();
+                for (Suggestion suggestion : suggestions.getList()) {
+                    String text = suggestion.getText();
+                    if(!text.isEmpty()) {
+                        candidates.add(new Candidate(text));
+                    }
+                }
+            } catch (Throwable error) {
+                LOGGER.error("Error finding command completions", error);
+            }
+        }
+
+    }
+
+}

--- a/server/src/main/java/org/loomdev/loom/LoomConsole.java
+++ b/server/src/main/java/org/loomdev/loom/LoomConsole.java
@@ -62,7 +62,7 @@ public class LoomConsole extends SimpleTerminalConsole {
                 Suggestions suggestions = server.getCommands().getDispatcher().getCompletionSuggestions(results).get();
                 for (Suggestion suggestion : suggestions.getList()) {
                     String text = suggestion.getText();
-                    if(!text.isEmpty()) {
+                    if (!text.isEmpty()) {
                         candidates.add(new Candidate(text));
                     }
                 }
@@ -70,7 +70,5 @@ public class LoomConsole extends SimpleTerminalConsole {
                 LOGGER.error("Error finding command completions", error);
             }
         }
-
     }
-
 }

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="com.mojang.util" shutdownHook="disable">
+<Configuration status="WARN" packages="com.mojang.util">
     <Appenders>
-        <TerminalConsole name="TerminalConsole">
-            <PatternLayout>
-                <LoggerNamePatternSelector defaultPattern="%highlightError{[%d{HH:mm:ss} %level]: [%logger] %minecraftFormatting{%msg}%n%xEx{full}}">
-                    <!-- Log root, Minecraft, Mojang and Bukkit loggers without prefix -->
-                    <!-- Disable prefix for various plugins that bypass the plugin logger -->
-                    <PatternMatch key=",net.minecraft.,Minecraft,com.mojang." pattern="%highlightError{[%d{HH:mm:ss} %level]: %minecraftFormatting{%msg}%n%xEx{full}}" />
+        <TerminalConsole name="Console">
+            <PatternLayout noConsoleNoAnsi="true">
+                <LoggerNamePatternSelector defaultPattern="%highlightError{[%d{HH:mm:ss}] [%t/%level]: [%logger] %minecraftFormatting{%msg}%n}">
+                    <PatternMatch key=",net.minecraft.,com.mojang.,org.loomdev.loom.,Minecraft,Plugin Manager" pattern="%highlightError{[%d{HH:mm:ss}] [%t/%level]: %minecraftFormatting{%msg}%n}" />
                 </LoggerNamePatternSelector>
             </PatternLayout>
         </TerminalConsole>
+        <Queue name="ServerGuiConsole">
+            <PatternLayout>
+				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level]: [%logger] %msg%n">
+					<PatternMatch key=",net.minecraft.,com.mojang.,org.loomdev.loom.,Minecraft,Plugin Manager" pattern="[%d{HH:mm:ss} %level]: %msg%n" />
+				</LoggerNamePatternSelector>
+			</PatternLayout>
+        </Queue>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
             <PatternLayout>
-                <LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level]: [%logger] %minecraftFormatting{%msg}{strip}%n%xEx{full}">
-                    <!-- Log root, Minecraft, Mojang and Bukkit loggers without prefix -->
-                    <!-- Disable prefix for various plugins that bypass the plugin logger -->
-                    <PatternMatch key=",net.minecraft.,Minecraft,com.mojang." pattern="[%d{HH:mm:ss}] [%t/%level]: %minecraftFormatting{%msg}{strip}%n%xEx{full}" />
+                <LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level]: [%logger] %msg%n">
+                    <PatternMatch key=",net.minecraft.,com.mojang.,org.loomdev.loom.,Minecraft,Plugin Manager" pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
                 </LoggerNamePatternSelector>
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy />
                 <OnStartupTriggeringPolicy />
             </Policies>
-            <DefaultRolloverStrategy max="1000"/>
         </RollingRandomAccessFile>
     </Appenders>
     <Loggers>
@@ -31,7 +33,8 @@
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL" />
             </filters>
             <AppenderRef ref="File"/>
-            <AppenderRef ref="TerminalConsole" level="info"/>
+            <AppenderRef ref="ServerGuiConsole"/>
+            <AppenderRef ref="Console" level="info"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/server/src/main/resources/log4j2.xml
+++ b/server/src/main/resources/log4j2.xml
@@ -10,10 +10,10 @@
         </TerminalConsole>
         <Queue name="ServerGuiConsole">
             <PatternLayout>
-				<LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level]: [%logger] %msg%n">
-					<PatternMatch key=",net.minecraft.,com.mojang.,org.loomdev.loom.,Minecraft,Plugin Manager" pattern="[%d{HH:mm:ss} %level]: %msg%n" />
-				</LoggerNamePatternSelector>
-			</PatternLayout>
+                <LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss} %level]: [%logger] %msg%n">
+                    <PatternMatch key=",net.minecraft.,com.mojang.,org.loomdev.loom.,Minecraft,Plugin Manager" pattern="[%d{HH:mm:ss} %level]: %msg%n" />
+                </LoggerNamePatternSelector>
+            </PatternLayout>
         </Queue>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
             <PatternLayout>


### PR DESCRIPTION
Adds support for command completion by pressing tab on the command line.
It also replaces the Log4j configuration file copied over from [Paper](https://github.com/PaperMC/Paper) with one that is better designed for Loom.
Even if this request is not accepted, it's not great that the Log4j configuration file is copied from a project with a stricter license.