### PR TITLE
Command line formatting support and other small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd Loom
 ```
 Once your environment is set up, you can open the project in your IDE of choice. If you have made an NMS modification and want to convert your changes to a patch, use `./loom rb` to rebuild patches. To apply all patches to existing NMS, use `./loom p`.
 
-To build a complete Loom JAR, run the setup commands above and then use `mvn package`. The final JAR will be inside the `target/` folder.
+To build a complete Loom JAR, you will need to have maven installed. Once installed, run the setup commands above followed by `./loom jar`. The final JAR will be inside the `target/` folder.
 
 We hope to create a stable and modern server software for many generations of Minecraft servers to come. Loom is completely open-source and licensed with the MIT license. Feel free to contribute to the project! ✨
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Loom uses Mojang's mapping names, which allows it to be quickly updated to new a
 Loom was created because of the lack of fast version updates from Spigot, CraftBukkit's parent project. Not to mention, Bukkit's ancient, by today's standards, API is in need of rewrites and optimizations. Loom aims to stick as faithful to the original Bukkit API as possible to make it easy for plugin developers to switch over, while also introducing many modern features and concepts directly into the API. The end goal is to completely deprecate the usage of NMS in plugins.
 
 ### Building Loom
-Loom provides all of the scripts necessary to set up a build environment in this repository. To set up a fresh build environment, run the following in a bash shell (WSL is preferable on Windows systems):
+Loom provides all of the scripts necessary to set up a build environment in this repository. To set up a fresh build environment, you need to have [Maven](https://maven.apache.org/) installed. Once installed, run the following in a bash shell ([WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) is preferable on Windows systems):
 ```bash
 git clone https://github.com/LoomDev/Loom
 cd Loom
@@ -19,9 +19,9 @@ cd Loom
 ```
 Once your environment is set up, you can open the project in your IDE of choice. If you have made an NMS modification and want to convert your changes to a patch, use `./loom rb` to rebuild patches. To apply all patches to existing NMS, use `./loom p`.
 
-To build a complete Loom JAR, you will need to have maven installed. Once installed, run the setup commands above followed by `./loom jar`. The final JAR will be inside the `target/` folder.
+To build a complete Loom JAR, run the setup commands above, followed by `./loom jar`. The final JAR will be inside the root folder (the folder Loom was cloned into).
 
-We hope to create a stable and modern server software for many generations of Minecraft servers to come. Loom is completely open-source and licensed with the MIT license. Feel free to contribute to the project! ✨
+We hope to create a stable and modern server software for many generations of Minecraft servers to come. Loom is completely open-source and licensed with the [MIT license](/LICENSE). Feel free to contribute to the project! ✨
 
 ### Special thanks
 [![JProfiler](https://www.ej-technologies.com/images/product_banners/jprofiler_medium.png)](https://www.ej-technologies.com/products/jprofiler/overview.html)  

--- a/api/src/main/java/org/loomdev/api/entity/player/Player.java
+++ b/api/src/main/java/org/loomdev/api/entity/player/Player.java
@@ -68,14 +68,14 @@ public interface Player extends LivingEntity {
      *
      * @param message The message of the action bar.
      */
-    void sendActionbar(@NotNull String message);
+    void sendActionBar(@NotNull String message);
 
     /**
      * Sends an action bar to the player that will appear above the hotbar.
      *
      * @param message The message of the action bar.
      */
-    void sendActionbar(@NotNull Component message);
+    void sendActionBar(@NotNull Component message);
 
     /**
      * Sends a title (with a subtitle below it) to the player.

--- a/api/src/main/java/org/loomdev/api/math/MathHelper.java
+++ b/api/src/main/java/org/loomdev/api/math/MathHelper.java
@@ -54,6 +54,6 @@ public final class MathHelper {
     }
 
     private MathHelper() {
-        throw new UnsupportedOperationException("You should be instantiating MathHelper");
+        throw new UnsupportedOperationException("MathHelper shouldn't be initialized.");
     }
 }

--- a/api/src/main/java/org/loomdev/api/sound/Sound.java
+++ b/api/src/main/java/org/loomdev/api/sound/Sound.java
@@ -1,9 +1,10 @@
 package org.loomdev.api.sound;
 
 import org.jetbrains.annotations.NotNull;
+import org.loomdev.api.entity.player.Player;
 
 /**
- * Represents a sound that can be played to players.
+ * Represents a sound that can be played to {@link Player}s.
  */
 public class Sound {
 

--- a/api/src/main/java/org/loomdev/api/sound/SoundEvent.java
+++ b/api/src/main/java/org/loomdev/api/sound/SoundEvent.java
@@ -4,7 +4,7 @@ import org.loomdev.api.Loom;
 import org.loomdev.api.util.registry.Keyed;
 
 /**
- * Represents a sound event (a sound that can be played to players).
+ * Represents a sound event (a type of {@link Sound}).
  */
 public interface SoundEvent extends Keyed {
 

--- a/api/src/main/java/org/loomdev/api/util/Hand.java
+++ b/api/src/main/java/org/loomdev/api/util/Hand.java
@@ -17,7 +17,7 @@ public enum Hand {
     /**
      * Gets the equipment slot corresponding to the hand.
      * 
-     * @return the slot
+     * @return The slot.
      */
     public EquipmentSlot getEquipmentSlot() {
         return equipmentSlot;

--- a/api/src/main/java/org/loomdev/api/util/NamespacedKey.java
+++ b/api/src/main/java/org/loomdev/api/util/NamespacedKey.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
  *
  *
  * <p>
- *     As of Minecraft 1.13 all item, blocks, ... use a namespaced key instead of an id. This provides more felixbility for modding
+ *     As of Minecraft 1.13 all item, blocks, etc. use a namespaced key instead of an id. This provides more flexibility for modding.
  * </p>
  *
  * <p>

--- a/server/patches/server/MinecraftServer.patch
+++ b/server/patches/server/MinecraftServer.patch
@@ -44,7 +44,20 @@
          MinecraftServer.LOGGER.info("Stopping server");
          if (this.getConnection() != null) {
              this.getConnection().stop();
-@@ -652,10 +658,13 @@
+@@ -618,6 +624,12 @@
+             MinecraftServer.LOGGER.error("Failed to unlock level {}", this.storageSource.getLevelId(), ioexception1);
+         }
+ 
++        // Loom start :: Terminal console appender
++        try {
++            net.minecrell.terminalconsole.TerminalConsoleAppender.close();
++        } catch(Throwable ignored) {
++        }
++        // Loom end
+     }
+ 
+     public String getLocalIp() {
+@@ -652,10 +664,13 @@
                  this.status.setVersion(new ServerStatus.Version(SharedConstants.getCurrentVersion().getName(), SharedConstants.getCurrentVersion().getProtocolVersion()));
                  this.updateStatusIcon(this.status);
  
@@ -60,7 +73,7 @@
                          long j = i / 50L;
  
                          MinecraftServer.LOGGER.warn("Can't keep up! Is the server overloaded? Running {}ms or {} ticks behind", i, j);
-@@ -663,6 +672,14 @@
+@@ -663,6 +678,14 @@
                          this.lastOverloadWarning = this.nextTickTime;
                      }
  
@@ -75,7 +88,7 @@
                      this.nextTickTime += 50L;
                      SingleTickProfiler singletickprofiler = SingleTickProfiler.createTickProfiler("Server");
  
-@@ -806,6 +823,7 @@
+@@ -806,6 +829,7 @@
          long i = Util.getNanos();
  
          ++this.tickCount;
@@ -83,7 +96,7 @@
          this.tickChildren(booleansupplier);
          if (i - this.lastServerStatus >= 5000000000L) {
              this.lastServerStatus = i;
-@@ -840,17 +858,20 @@
+@@ -840,17 +864,20 @@
          }
  
          this.profiler.pop();
@@ -104,7 +117,7 @@
          this.profiler.push("commandFunctions");
          this.getFunctions().tick();
          this.profiler.popPush("levels");
-@@ -871,6 +892,7 @@
+@@ -871,6 +898,7 @@
              this.profiler.push("tick");
  
              try {
@@ -112,7 +125,7 @@
                  serverlevel.tick(booleansupplier);
              } catch (Throwable throwable) {
                  CrashReport crashreport = CrashReport.forThrowable(throwable, "Exception ticking world");
-@@ -950,7 +972,7 @@
+@@ -950,7 +978,7 @@
      }
  
      public String getServerModName() {
@@ -121,7 +134,16 @@
      }
  
      public CrashReport fillReport(CrashReport crashreport) {
-@@ -1289,11 +1311,11 @@
+@@ -991,7 +1019,7 @@
+     public abstract Optional<String> getModdedStatus();
+ 
+     public void sendMessage(Component component, UUID uuid) {
+-        MinecraftServer.LOGGER.info(component.getString());
++        MinecraftServer.LOGGER.info(org.loomdev.loom.util.ChatUtil.toString(component)); // Loom :: Show formatting in console
+     }
+ 
+     public KeyPair getKeyPair() {
+@@ -1289,11 +1317,11 @@
  
      public CompletableFuture<Void> reloadResources(Collection<String> collection) {
          CompletableFuture<Void> completablefuture = CompletableFuture.supplyAsync(() -> {
@@ -135,7 +157,7 @@
          }, this).thenCompose((immutablelist) -> {
              return ServerResources.loadResources(immutablelist, this.registryHolder, this.isDedicatedServer() ? Commands.CommandSelection.DEDICATED : Commands.CommandSelection.INTEGRATED, this.getFunctionCompilationLevel(), this.executor, this);
          }).thenAcceptAsync((serverresources) -> {
-@@ -1735,6 +1757,7 @@
+@@ -1735,6 +1763,7 @@
          return null;
      }
  
@@ -143,7 +165,7 @@
      public void doRunTask(Runnable runnable) {
          this.doRunTask((TickTask) runnable);
      }
-@@ -1746,4 +1769,5 @@
+@@ -1746,4 +1775,5 @@
      public Runnable wrapRunnable(Runnable runnable) {
          return this.wrapRunnable(runnable);
      }

--- a/server/patches/server/MinecraftServer.patch
+++ b/server/patches/server/MinecraftServer.patch
@@ -139,7 +139,7 @@
  
      public void sendMessage(Component component, UUID uuid) {
 -        MinecraftServer.LOGGER.info(component.getString());
-+        MinecraftServer.LOGGER.info(org.loomdev.loom.util.ChatUtil.toString(component)); // Loom :: Show formatting in console
++        MinecraftServer.LOGGER.info(org.loomdev.loom.util.ChatToLegacyConverter.toLegacy(component)); // Loom :: Show formatting in console
      }
  
      public KeyPair getKeyPair() {

--- a/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
+++ b/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
@@ -1,11 +1,9 @@
 package org.loomdev.loom.entity.player;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import net.minecraft.Util;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.ChatType;
-import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitlesPacket;
 import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
@@ -15,25 +13,17 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.level.GameType;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.loomdev.api.Loom;
-import org.loomdev.api.bossbar.BossBar;
-import org.loomdev.api.entity.Entity;
 import org.loomdev.api.entity.EntityType;
 import org.loomdev.api.entity.player.Player;
 import org.loomdev.api.math.MathHelper;
 import org.loomdev.api.sound.Sound;
 import org.loomdev.api.util.GameMode;
-import org.loomdev.api.world.Location;
-import org.loomdev.api.world.Weather;
 import org.loomdev.loom.entity.LivingEntityImpl;
 import org.loomdev.loom.util.transformer.TextTransformer;
 
 import java.net.InetSocketAddress;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 
 public class PlayerImpl extends LivingEntityImpl implements Player {
 
@@ -115,12 +105,12 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
     }
 
     @Override
-    public void sendActionbar(@NotNull String message) {
-        sendActionbar(Component.text(message));
+    public void sendActionBar(@NotNull String message) {
+        sendActionBar(Component.text(message));
     }
 
     @Override
-    public void sendActionbar(@NotNull Component message) {
+    public void sendActionBar(@NotNull Component message) {
         getMinecraftEntity().sendMessage(TextTransformer.toMinecraft(message), ChatType.GAME_INFO, Util.NIL_UUID);
     }
 

--- a/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
+++ b/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
@@ -1,9 +1,11 @@
 package org.loomdev.loom.entity.player;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.minecraft.Util;
 import net.minecraft.core.Registry;
 import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitlesPacket;
 import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
@@ -13,17 +15,25 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.Pose;
 import net.minecraft.world.level.GameType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.loomdev.api.Loom;
+import org.loomdev.api.bossbar.BossBar;
+import org.loomdev.api.entity.Entity;
 import org.loomdev.api.entity.EntityType;
 import org.loomdev.api.entity.player.Player;
 import org.loomdev.api.math.MathHelper;
 import org.loomdev.api.sound.Sound;
 import org.loomdev.api.util.GameMode;
+import org.loomdev.api.world.Location;
+import org.loomdev.api.world.Weather;
 import org.loomdev.loom.entity.LivingEntityImpl;
 import org.loomdev.loom.util.transformer.TextTransformer;
 
 import java.net.InetSocketAddress;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 public class PlayerImpl extends LivingEntityImpl implements Player {
 

--- a/server/src/main/java/org/loomdev/loom/scheduler/ScheduledTaskImpl.java
+++ b/server/src/main/java/org/loomdev/loom/scheduler/ScheduledTaskImpl.java
@@ -103,7 +103,7 @@ public class ScheduledTaskImpl extends FutureTask<Void> implements ScheduledTask
         try {
             get();
         } catch (ExecutionException ex) {
-            LogManager.getLogger("Loom task logger - #" + taskId).log(Level.ERROR, "Error while executing " + this, ex.getCause());
+            LogManager.getLogger("Task logger - #" + taskId).log(Level.ERROR, "Error while executing " + this, ex.getCause());
         } catch (InterruptedException e) {
             // Task is already done
         }

--- a/server/src/main/java/org/loomdev/loom/util/ChatToLegacyConverter.java
+++ b/server/src/main/java/org/loomdev/loom/util/ChatToLegacyConverter.java
@@ -6,49 +6,67 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
-import org.checkerframework.checker.guieffect.qual.SafeType;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class ChatUtil {
+public class ChatToLegacyConverter {
 
-    public static String toString(Component component) {
+    /**
+     * Converts a text component to a legacy string
+     * with colors replaced with their legacy codes
+     * (§ followed by a number or letter).
+     *
+     * @return The legacy string.
+     * @see https://minecraft.gamepedia.com/Formatting_codes
+     */
+    public static String toLegacy(Component component) {
         if (component == null) {
             return "";
         }
         StringBuilder result = new StringBuilder();
 
-        for (Component subComponent : components(component)) {
+        List<Component> components = stream(component).collect(Collectors.toList());
+        boolean hasFormatting = false;
+        for (Component subComponent : components) {
+            if (hasFormatting) {
+                // If the previous component was formatted, clear all formatting.
+                hasFormatting = false;
+                result.append(ChatFormatting.RESET);
+            }
             Style style = subComponent.getStyle();
             TextColor color = style.getColor();
 
             if (color != null) {
+                // Attempt to convert the colour to legacy
                 try {
                     result.append(ChatFormatting.valueOf(color.toString().toUpperCase()));
+                    hasFormatting = true;
                 } catch(IllegalArgumentException ignored) {
-                    result.append("§x");
-                    for (char character : color.toString().substring(1).toCharArray()) {
-                        result.append("§" + character);
-                    }
+                    // Legacy does not support RGB
                 }
             }
 
             if (style.isBold()) {
+                hasFormatting = true;
                 result.append(ChatFormatting.BOLD);
             }
             if (style.isItalic()) {
+                hasFormatting = true;
                 result.append(ChatFormatting.ITALIC);
             }
             if (style.isUnderlined()) {
+                hasFormatting = true;
                 result.append(ChatFormatting.UNDERLINE);
             }
             if (style.isStrikethrough()) {
+                hasFormatting = true;
                 result.append(ChatFormatting.STRIKETHROUGH);
             }
             if (style.isObfuscated()) {
+                hasFormatting = true;
                 result.append(ChatFormatting.OBFUSCATED);
             }
 
@@ -61,11 +79,11 @@ public class ChatUtil {
         return result.toString();
     }
 
-    public static Stream<Component> stream(Component component) {
-        return Streams.concat(Stream.of(component), component.getSiblings().stream().flatMap(ChatUtil::stream));
+    private static Stream<Component> stream(Component component) {
+        return Streams.concat(Stream.of(component), component.getSiblings().stream().flatMap(ChatToLegacyConverter::stream));
     }
 
-    public static List<Component> components(Component component) {
-        return stream(component).collect(Collectors.toList());
+    private ChatToLegacyConverter() {
+        throw new UnsupportedOperationException("ChatToLegacyConverter shouldn't be initialized.");
     }
 }

--- a/server/src/main/java/org/loomdev/loom/util/ChatUtil.java
+++ b/server/src/main/java/org/loomdev/loom/util/ChatUtil.java
@@ -1,0 +1,71 @@
+package org.loomdev.loom.util;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Streams;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ChatUtil {
+
+    public static String toString(Component component) {
+        if (component == null) {
+            return "";
+        }
+        StringBuilder result = new StringBuilder();
+
+        for (Component subComponent : components(component)) {
+            Style style = subComponent.getStyle();
+            TextColor color = style.getColor();
+
+            if (color != null) {
+                try {
+                    result.append(ChatFormatting.valueOf(color.toString().toUpperCase()));
+                } catch(IllegalArgumentException ignored) {
+                    result.append("§x");
+                    for (char character : color.toString().substring(1).toCharArray()) {
+                        result.append("§" + character);
+                    }
+                }
+            }
+
+            if (style.isBold()) {
+                result.append(ChatFormatting.BOLD);
+            }
+            if (style.isItalic()) {
+                result.append(ChatFormatting.ITALIC);
+            }
+            if (style.isUnderlined()) {
+                result.append(ChatFormatting.UNDERLINE);
+            }
+            if (style.isStrikethrough()) {
+                result.append(ChatFormatting.STRIKETHROUGH);
+            }
+            if (style.isObfuscated()) {
+                result.append(ChatFormatting.OBFUSCATED);
+            }
+
+            subComponent.visitSelf((string) -> {
+               result.append(string);
+               return Optional.empty();
+            });
+        }
+
+        return result.toString();
+    }
+
+    public static Stream<Component> stream(Component component) {
+        return Streams.concat(Stream.of(component), component.getSiblings().stream().flatMap(ChatUtil::stream));
+    }
+
+    public static List<Component> components(Component component) {
+        return stream(component).collect(Collectors.toList());
+    }
+}

--- a/tools/scripts/buildJar.sh
+++ b/tools/scripts/buildJar.sh
@@ -3,7 +3,7 @@
 mcVersion=$(cat ".loomversion")
 
 buildJar() {
-    printf "Building distributable Loom server jar for Minecraft $mcVersion..."
+    printf "Building distributable Loom server jar for Minecraft $mcVersion...\n"
     rootPath=$(pwd)
 
     cd "tools/Paperclip"
@@ -11,7 +11,7 @@ buildJar() {
     cp "assembly/target/paperclip-$mcVersion.jar" "$rootPath/loom-$mcVersion.jar"
     cd ../..
     
-    printf " Done!\n"
+    printf "Done!"
 }
 
 buildJar


### PR DESCRIPTION
Adds support for chat formatting in the command line.
It also adds some small improvements:

- `mvn package` -> `./loom jar` (uses `mvn clean package` meaning that old classes and javadoc doesn't hang around)
- sendActionbar -> sendActionBar (action bar is 2 words)
- Fix spelling in javadoc.
- Adds more links to javadoc.
- Changes `Loom task logger - <task number>` to `Task logger - <task number>`