### PR TITLE
Add damage sources

### DIFF
--- a/api/src/main/java/org/loomdev/api/entity/Damageable.java
+++ b/api/src/main/java/org/loomdev/api/entity/Damageable.java
@@ -1,5 +1,7 @@
 package org.loomdev.api.entity;
 
+import org.loomdev.api.entity.damage.DamageSource;
+
 /**
  * Represents an entity with health.
  */
@@ -8,6 +10,8 @@ public interface Damageable extends Entity {
     void damage(float amount);
 
     void damage(float amount, Entity source);
+
+    void damage(float amount, DamageSource source);
 
     float getHealth();
 

--- a/api/src/main/java/org/loomdev/api/entity/damage/DamageSource.java
+++ b/api/src/main/java/org/loomdev/api/entity/damage/DamageSource.java
@@ -44,7 +44,7 @@ public enum DamageSource {
     /**
      * Damage caused by being out of water.
      */
-    DRYOUT("dryout"),
+    DRY_OUT("dryout"),
     SWEET_BERRY_BUSH("sweetBerryBush"),
     FREEZE("freeze"),
     FALLING_STALACTITE("fallingStalactite");

--- a/api/src/main/java/org/loomdev/api/entity/damage/DamageSource.java
+++ b/api/src/main/java/org/loomdev/api/entity/damage/DamageSource.java
@@ -18,7 +18,7 @@ public enum DamageSource {
     /**
      * Damage caused by being inside a block.
      */
-    IN_WALL("inWall"),
+    INSIDE_BLOCK("inWall"),
     /**
      * Damage caused by too many entities being in the same spot.
      */

--- a/api/src/main/java/org/loomdev/api/entity/damage/DamageSource.java
+++ b/api/src/main/java/org/loomdev/api/entity/damage/DamageSource.java
@@ -1,5 +1,85 @@
 package org.loomdev.api.entity.damage;
 
-// TODO add some sources
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * Represents a cause of damage.
+ */
 public enum DamageSource {
+    IN_FIRE("inFire"),
+    LIGHTNING_BOLT("lightningBolt"),
+    ON_FIRE("onFire"),
+    LAVA("lava"),
+    /**
+     * Damage caused by magma blocks.
+     */
+    HOT_FLOOR("hotFloor"),
+    /**
+     * Damage caused by being inside a block.
+     */
+    IN_WALL("inWall"),
+    /**
+     * Damage caused by too many entities being in the same spot.
+     */
+    CRAMMING("cramming"),
+    DROWN("drown"),
+    STARVE("starve"),
+    CACTUS("cactus"),
+    FALL("fall"),
+    FLY_INTO_WALL("flyIntoWall"),
+    OUT_OF_WORLD("outOfWorld"),
+    /**
+     * Damage caused for no particular reason.
+     */
+    GENERIC("generic"),
+    /**
+     * Damage caused by potions.
+     */
+    MAGIC("magic"),
+    WITHER("wither"),
+    FALLING_ANVIL("anvil"),
+    FALLING_BLOCK("fallingBlock"),
+    DRAGON_BREATH("dragonBreath"),
+    /**
+     * Damage caused by being out of water.
+     */
+    DRYOUT("dryout"),
+    SWEET_BERRY_BUSH("sweetBerryBush"),
+    FREEZE("freeze"),
+    FALLING_STALACTITE("fallingStalactite");
+
+    private static Map<String, DamageSource> byName = new HashMap<>();
+    private String name;
+
+    DamageSource(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the name of the damage source.
+     * Unlike {@link #name()}, it returns the name in the format {@code damageSource}.
+     *
+     * @return The name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets a damage source by its name.
+     * Unlike {@link #valueOf(String)}, the name is in the format {@code damageSource}.
+     *
+     * @param name The name.
+     * @return The source.
+     */
+    public static DamageSource getByName(String name) {
+        return byName.get(name);
+    }
+
+    static {
+        for (DamageSource source : values()) {
+            byName.put(source.getName(), source);
+        }
+    }
 }

--- a/server/src/main/java/org/loomdev/loom/entity/EntityImpl.java
+++ b/server/src/main/java/org/loomdev/loom/entity/EntityImpl.java
@@ -22,6 +22,7 @@ import org.loomdev.api.world.World;
 import org.loomdev.loom.command.CommandSourceImpl;
 import org.loomdev.loom.item.ItemStackImpl;
 import org.loomdev.loom.util.transformer.TextTransformer;
+import org.loomdev.loom.util.transformer.DamageSourceTransformer;
 import org.loomdev.loom.world.WorldImpl;
 
 import java.util.ArrayList;
@@ -355,7 +356,7 @@ public abstract class EntityImpl extends CommandSourceImpl implements Entity {
 
     @Override
     public boolean isInvulnerableTo(DamageSource damageSource) {
-        return false; // TODO
+        return getMinecraftEntity().isInvulnerableTo(DamageSourceTransformer.toMinecraft(damageSource));
     }
 
     @Override

--- a/server/src/main/java/org/loomdev/loom/entity/LivingEntityImpl.java
+++ b/server/src/main/java/org/loomdev/loom/entity/LivingEntityImpl.java
@@ -20,6 +20,7 @@ import org.loomdev.loom.entity.player.PlayerImpl;
 import org.loomdev.loom.item.ItemStackImpl;
 import org.loomdev.loom.util.transformer.StatusEffectTransformer;
 import org.loomdev.loom.util.transformer.StatusEffectTypeTransformer;
+import org.loomdev.loom.util.transformer.DamageSourceTransformer;
 import org.loomdev.loom.world.WorldImpl;
 
 import java.util.List;
@@ -304,7 +305,7 @@ public abstract class LivingEntityImpl extends EntityImpl implements LivingEntit
 
     @Override
     public void damage(float damage) {
-        this.damage(damage, null);
+        getMinecraftEntity().hurt(DamageSource.GENERIC, damage);
     }
 
     @Override
@@ -316,6 +317,11 @@ public abstract class LivingEntityImpl extends EntityImpl implements LivingEntit
             reason = DamageSource.mobAttack(((LivingEntityImpl) source).getMinecraftEntity());
         }
         getMinecraftEntity().hurt(reason, damage);
+    }
+
+    @Override
+    public void damage(float damage, org.loomdev.api.entity.damage.DamageSource source) {
+        getMinecraftEntity().hurt(DamageSourceTransformer.toMinecraft(source), damage);
     }
 
     @Override

--- a/server/src/main/java/org/loomdev/loom/util/transformer/DamageSourceTransformer.java
+++ b/server/src/main/java/org/loomdev/loom/util/transformer/DamageSourceTransformer.java
@@ -50,7 +50,7 @@ public class DamageSourceTransformer {
                 return DamageSource.FALLING_BLOCK;
             case DRAGON_BREATH:
                 return DamageSource.DRAGON_BREATH;
-            case DRYOUT:
+            case DRY_OUT:
                 return DamageSource.DRY_OUT;
             case SWEET_BERRY_BUSH:
                 return DamageSource.SWEET_BERRY_BUSH;

--- a/server/src/main/java/org/loomdev/loom/util/transformer/DamageSourceTransformer.java
+++ b/server/src/main/java/org/loomdev/loom/util/transformer/DamageSourceTransformer.java
@@ -1,0 +1,65 @@
+package org.loomdev.loom.util.transformer;
+
+import net.minecraft.world.damagesource.DamageSource;
+import org.jetbrains.annotations.NotNull;
+
+public class DamageSourceTransformer {
+
+    private DamageSourceTransformer() {
+        throw new UnsupportedOperationException("DamageSourceTransformer shouldn't be initialized.");
+    }
+
+    @NotNull
+    public static DamageSource toMinecraft(org.loomdev.api.entity.damage.DamageSource source) {
+        switch (source) {
+            case IN_FIRE:
+                return DamageSource.IN_FIRE;
+            case LIGHTNING_BOLT:
+                return DamageSource.LIGHTNING_BOLT;
+            case ON_FIRE:
+                return DamageSource.ON_FIRE;
+            case LAVA:
+                return DamageSource.LAVA;
+            case HOT_FLOOR:
+                return DamageSource.HOT_FLOOR;
+            case IN_WALL:
+                return DamageSource.IN_WALL;
+            case CRAMMING:
+                return DamageSource.CRAMMING;
+            case DROWN:
+                return DamageSource.DROWN;
+            case STARVE:
+                return DamageSource.STARVE;
+            case CACTUS:
+                return DamageSource.CACTUS;
+            case FALL:
+                return DamageSource.FALL;
+            case FLY_INTO_WALL:
+                return DamageSource.FLY_INTO_WALL;
+            case OUT_OF_WORLD:
+                return DamageSource.OUT_OF_WORLD;
+            case GENERIC:
+                return DamageSource.GENERIC;
+            case MAGIC:
+                return DamageSource.MAGIC;
+            case WITHER:
+                return DamageSource.WITHER;
+            case FALLING_ANVIL:
+                return DamageSource.ANVIL;
+            case FALLING_BLOCK:
+                return DamageSource.FALLING_BLOCK;
+            case DRAGON_BREATH:
+                return DamageSource.DRAGON_BREATH;
+            case DRYOUT:
+                return DamageSource.DRY_OUT;
+            case SWEET_BERRY_BUSH:
+                return DamageSource.SWEET_BERRY_BUSH;
+            case FREEZE:
+                return DamageSource.FREEZE;
+            case FALLING_STALACTITE:
+                return DamageSource.FALLING_STALACTITE;
+            default:
+                return DamageSource.GENERIC;
+        }
+    }
+}

--- a/server/src/main/java/org/loomdev/loom/util/transformer/DamageSourceTransformer.java
+++ b/server/src/main/java/org/loomdev/loom/util/transformer/DamageSourceTransformer.java
@@ -22,7 +22,7 @@ public class DamageSourceTransformer {
                 return DamageSource.LAVA;
             case HOT_FLOOR:
                 return DamageSource.HOT_FLOOR;
-            case IN_WALL:
+            case INSIDE_BLOCK:
                 return DamageSource.IN_WALL;
             case CRAMMING:
                 return DamageSource.CRAMMING;
@@ -59,7 +59,7 @@ public class DamageSourceTransformer {
             case FALLING_STALACTITE:
                 return DamageSource.FALLING_STALACTITE;
             default:
-                return DamageSource.GENERIC;
+                throw new UnsupportedOperationException("Cannot convert damage source " + source.getName() + " to Minecraft.");
         }
     }
 }


### PR DESCRIPTION
Adds damage sources to the DamageSource enum.
No tests were added, because the names in the API are slightly different to the names in Minecraft (e.g. ANVIL -> FALLING_ANVIL).

Sorry if I'm creating too many pull requests.