### PR TITLE
More message sending API

### DIFF
--- a/api/src/main/java/org/loomdev/api/command/CommandSource.java
+++ b/api/src/main/java/org/loomdev/api/command/CommandSource.java
@@ -22,9 +22,9 @@ public interface CommandSource extends CommandSourceConsumable, PermissionSubjec
      * Sends a message to the command source.
      *
      * @param message The message (as a legacy string).
-     * @param uuid The sender's UUID (used for blocking players on the client).
+     * @param sender The sender's UUID (used for blocking players on the client).
      */
-    void sendMessage(@NotNull String message, @NotNull UUID uuid);
+    void sendMessage(@NotNull String message, @NotNull UUID sender);
 
     /**
      * Sends a message to the command source.
@@ -37,43 +37,51 @@ public interface CommandSource extends CommandSourceConsumable, PermissionSubjec
      * Sends a message to the command source.
      *
      * @param message The message (as a text component).
-     * @param uuid The sender's UUID (used for blocking players on the client).
+     * @param sender The sender's UUID (used for blocking players on the client).
      */
-    void sendMessage(@NotNull Component message, @NotNull UUID uuid);
+    void sendMessage(@NotNull Component message, @NotNull UUID sender);
 
     /**
      * Sends an error message to the command source.
-     * Error messages appear in red.
+     * This does not change formatting by default.
      *
      * @param message The message (as a legacy string).
      */
-    void sendError(@NotNull String message);
+    default void sendError(@NotNull String message) {
+        sendMessage(message);
+    }
 
     /**
      * Sends an error message to the command source.
-     * Error messages appear in red.
+     * This does not change formatting by default.
      *
      * @param message The message (as a legacy string).
-     * @param uuid The sender's UUID (used for blocking players on the client).
+     * @param sender The sender's UUID (used for blocking players on the client).
      */
-    void sendError(@NotNull String message, @NotNull UUID uuid);
+    default void sendError(@NotNull String message, @NotNull UUID sender) {
+        sendMessage(message, sender);
+    }
 
     /**
      * Sends an error message to the command source.
-     * Error messages appear in red.
+     * This does not change formatting by default.
      *
      * @param message The message (as a legacy string).
      */
-    void sendError(@NotNull Component message);
+    default void sendError(@NotNull Component message) {
+        sendMessage(message);
+    }
 
     /**
      * Sends an error message to the command source.
-     * Error messages appear in red.
+     * This does not change formatting by default.
      *
      * @param message The message (as a text component).
-     * @param uuid The sender's UUID (used for blocking players on the client).
+     * @param sender The sender's UUID (used for blocking players on the client).
      */
-    void sendError(@NotNull Component message, @NotNull UUID uuid);
+    default void sendError(@NotNull Component message, @NotNull UUID sender) {
+        sendMessage(message, sender);
+    }
 
     // TODO getName, broadcastToOps
 }

--- a/api/src/main/java/org/loomdev/api/command/CommandSource.java
+++ b/api/src/main/java/org/loomdev/api/command/CommandSource.java
@@ -41,47 +41,5 @@ public interface CommandSource extends CommandSourceConsumable, PermissionSubjec
      */
     void sendMessage(@NotNull Component message, @NotNull UUID sender);
 
-    /**
-     * Sends an error message to the command source.
-     * This does not change formatting by default.
-     *
-     * @param message The message (as a legacy string).
-     */
-    default void sendError(@NotNull String message) {
-        sendMessage(message);
-    }
-
-    /**
-     * Sends an error message to the command source.
-     * This does not change formatting by default.
-     *
-     * @param message The message (as a legacy string).
-     * @param sender The sender's UUID (used for blocking players on the client).
-     */
-    default void sendError(@NotNull String message, @NotNull UUID sender) {
-        sendMessage(message, sender);
-    }
-
-    /**
-     * Sends an error message to the command source.
-     * This does not change formatting by default.
-     *
-     * @param message The message (as a legacy string).
-     */
-    default void sendError(@NotNull Component message) {
-        sendMessage(message);
-    }
-
-    /**
-     * Sends an error message to the command source.
-     * This does not change formatting by default.
-     *
-     * @param message The message (as a text component).
-     * @param sender The sender's UUID (used for blocking players on the client).
-     */
-    default void sendError(@NotNull Component message, @NotNull UUID sender) {
-        sendMessage(message, sender);
-    }
-
     // TODO getName, broadcastToOps
 }

--- a/api/src/main/java/org/loomdev/api/command/CommandSource.java
+++ b/api/src/main/java/org/loomdev/api/command/CommandSource.java
@@ -4,12 +4,76 @@ import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 import org.loomdev.api.permissions.PermissionSubject;
 
+import java.util.UUID;
+
 /**
  * Represents anything that can execute commands and receive messages.
  */
 public interface CommandSource extends CommandSourceConsumable, PermissionSubject {
 
+    /**
+     * Sends a message to the command source.
+     *
+     * @param message The message (as a legacy string).
+     */
     void sendMessage(@NotNull String message);
 
+    /**
+     * Sends a message to the command source.
+     *
+     * @param message The message (as a legacy string).
+     * @param uuid The sender's UUID (used for blocking players on the client).
+     */
+    void sendMessage(@NotNull String message, @NotNull UUID uuid);
+
+    /**
+     * Sends a message to the command source.
+     *
+     * @param message The message (as a text component).
+     */
     void sendMessage(@NotNull Component message);
+
+    /**
+     * Sends a message to the command source.
+     *
+     * @param message The message (as a text component).
+     * @param uuid The sender's UUID (used for blocking players on the client).
+     */
+    void sendMessage(@NotNull Component message, @NotNull UUID uuid);
+
+    /**
+     * Sends an error message to the command source.
+     * Error messages appear in red.
+     *
+     * @param message The message (as a legacy string).
+     */
+    void sendError(@NotNull String message);
+
+    /**
+     * Sends an error message to the command source.
+     * Error messages appear in red.
+     *
+     * @param message The message (as a legacy string).
+     * @param uuid The sender's UUID (used for blocking players on the client).
+     */
+    void sendError(@NotNull String message, @NotNull UUID uuid);
+
+    /**
+     * Sends an error message to the command source.
+     * Error messages appear in red.
+     *
+     * @param message The message (as a legacy string).
+     */
+    void sendError(@NotNull Component message);
+
+    /**
+     * Sends an error message to the command source.
+     * Error messages appear in red.
+     *
+     * @param message The message (as a text component).
+     * @param uuid The sender's UUID (used for blocking players on the client).
+     */
+    void sendError(@NotNull Component message, @NotNull UUID uuid);
+
+    // TODO getName, broadcastToOps
 }

--- a/api/src/main/java/org/loomdev/api/util/ChatColor.java
+++ b/api/src/main/java/org/loomdev/api/util/ChatColor.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.text.format.TextColor;
 /**
  * Chat color utilities.
  */
+// TODO replace with net.kyori.adventure.text.format.NamedTextColor
 public class ChatColor {
 
     public static final char COLOR_CHAR = '\u00A7';

--- a/server/src/main/java/org/loomdev/loom/command/CommandSourceImpl.java
+++ b/server/src/main/java/org/loomdev/loom/command/CommandSourceImpl.java
@@ -1,9 +1,11 @@
 package org.loomdev.loom.command;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.minecraft.Util;
 import org.jetbrains.annotations.NotNull;
 import org.loomdev.api.Loom;
+import org.loomdev.api.util.ChatColor;
 import org.loomdev.api.command.CommandSource;
 import org.loomdev.api.command.CommandSourceConsumable;
 import org.loomdev.api.command.ConsoleCommandSource;
@@ -11,6 +13,7 @@ import org.loomdev.api.entity.player.Player;
 import org.loomdev.loom.util.transformer.TextTransformer;
 
 import java.util.function.Consumer;
+import java.util.UUID;
 
 public class CommandSourceImpl implements CommandSource {
 
@@ -72,8 +75,43 @@ public class CommandSourceImpl implements CommandSource {
     }
 
     @Override
+    public void sendMessage(@NotNull String message, @NotNull UUID uuid) {
+        sendMessage(Component.text(message), uuid);
+    }
+
+    @Override
     public void sendMessage(@NotNull Component message) {
         source.sendMessage(TextTransformer.toMinecraft(message), Util.NIL_UUID);
+    }
+
+    @Override
+    public void sendMessage(@NotNull Component message, @NotNull UUID uuid) {
+        source.sendMessage(TextTransformer.toMinecraft(message), uuid);
+    }
+
+    @Override
+    public void sendError(@NotNull String message) {
+        sendError(Component.text(message));
+    }
+
+    @Override
+    public void sendError(@NotNull String message, @NotNull UUID uuid) {
+        sendError(Component.text(message), uuid);
+    }
+
+    @Override
+    public void sendError(@NotNull Component message) {
+        sendMessage(toError(message));
+    }
+
+    @Override
+    @Deprecated
+    public void sendError(@NotNull Component message, @NotNull UUID uuid) {
+        sendMessage(toError(message), uuid);
+    }
+
+    private Component toError(Component component) {
+        return Component.text("").append(component).color(ChatColor.RED);
     }
 
     @Override

--- a/server/src/main/java/org/loomdev/loom/command/CommandSourceImpl.java
+++ b/server/src/main/java/org/loomdev/loom/command/CommandSourceImpl.java
@@ -25,11 +25,6 @@ public class CommandSourceImpl implements CommandSource {
         this.source = source;
     }
 
-    @NotNull
-    public net.minecraft.commands.CommandSource getMinecraftSource() {
-        return source;
-    }
-
     @Override
     public boolean isPlayer() {
         return this instanceof Player;

--- a/server/src/main/java/org/loomdev/loom/command/CommandSourceImpl.java
+++ b/server/src/main/java/org/loomdev/loom/command/CommandSourceImpl.java
@@ -25,6 +25,11 @@ public class CommandSourceImpl implements CommandSource {
         this.source = source;
     }
 
+    @NotNull
+    public net.minecraft.commands.CommandSource getMinecraftSource() {
+        return source;
+    }
+
     @Override
     public boolean isPlayer() {
         return this instanceof Player;
@@ -75,43 +80,18 @@ public class CommandSourceImpl implements CommandSource {
     }
 
     @Override
-    public void sendMessage(@NotNull String message, @NotNull UUID uuid) {
-        sendMessage(Component.text(message), uuid);
+    public void sendMessage(@NotNull String message, @NotNull UUID sender) {
+        sendMessage(Component.text(message), sender);
     }
 
     @Override
     public void sendMessage(@NotNull Component message) {
-        source.sendMessage(TextTransformer.toMinecraft(message), Util.NIL_UUID);
+        sendMessage(message, Util.NIL_UUID);
     }
 
     @Override
-    public void sendMessage(@NotNull Component message, @NotNull UUID uuid) {
-        source.sendMessage(TextTransformer.toMinecraft(message), uuid);
-    }
-
-    @Override
-    public void sendError(@NotNull String message) {
-        sendError(Component.text(message));
-    }
-
-    @Override
-    public void sendError(@NotNull String message, @NotNull UUID uuid) {
-        sendError(Component.text(message), uuid);
-    }
-
-    @Override
-    public void sendError(@NotNull Component message) {
-        sendMessage(toError(message));
-    }
-
-    @Override
-    @Deprecated
-    public void sendError(@NotNull Component message, @NotNull UUID uuid) {
-        sendMessage(toError(message), uuid);
-    }
-
-    private Component toError(Component component) {
-        return Component.text("").append(component).color(ChatColor.RED);
+    public void sendMessage(@NotNull Component message, @NotNull UUID sender) {
+        source.sendMessage(TextTransformer.toMinecraft(message), sender);
     }
 
     @Override

--- a/server/src/main/java/org/loomdev/loom/command/ConsoleCommandSourceImpl.java
+++ b/server/src/main/java/org/loomdev/loom/command/ConsoleCommandSourceImpl.java
@@ -1,51 +1,12 @@
 package org.loomdev.loom.command;
 
-import net.kyori.adventure.text.Component;
 import net.minecraft.commands.CommandSource;
 import org.loomdev.api.command.ConsoleCommandSource;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.loomdev.loom.util.ChatToLegacyConverter;
-import org.loomdev.loom.util.transformer.TextTransformer;
-
-import java.util.UUID;
 
 public class ConsoleCommandSourceImpl extends CommandSourceImpl implements ConsoleCommandSource {
 
-    private static final Logger LOGGER = LogManager.getLogger();
-
     public ConsoleCommandSourceImpl(CommandSource source) {
         super(source);
-    }
-
-    @Override
-    public void sendMessage(String message, UUID sender) {
-        LOGGER.info(message);
-    }
-
-    @Override
-    public void sendMessage(Component message, UUID sender) {
-        LOGGER.info(ChatToLegacyConverter.toLegacy(message));
-    }
-
-    @Override
-    public void sendError(String message) {
-        LOGGER.error(message);
-    }
-
-    @Override
-    public void sendError(String message, UUID sender) {
-        sendError(message);
-    }
-
-    @Override
-    public void sendError(Component message) {
-        LOGGER.error(ChatToLegacyConverter.toLegacy(message));
-    }
-
-    @Override
-    public void sendError(Component message, UUID sender) {
-        sendError(message);
     }
 
     @Override

--- a/server/src/main/java/org/loomdev/loom/command/ConsoleCommandSourceImpl.java
+++ b/server/src/main/java/org/loomdev/loom/command/ConsoleCommandSourceImpl.java
@@ -1,12 +1,51 @@
 package org.loomdev.loom.command;
 
+import net.kyori.adventure.text.Component;
 import net.minecraft.commands.CommandSource;
 import org.loomdev.api.command.ConsoleCommandSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.loomdev.loom.util.ChatToLegacyConverter;
+import org.loomdev.loom.util.transformer.TextTransformer;
+
+import java.util.UUID;
 
 public class ConsoleCommandSourceImpl extends CommandSourceImpl implements ConsoleCommandSource {
 
+    private static final Logger LOGGER = LogManager.getLogger();
+
     public ConsoleCommandSourceImpl(CommandSource source) {
         super(source);
+    }
+
+    @Override
+    public void sendMessage(String message, UUID sender) {
+        LOGGER.info(message);
+    }
+
+    @Override
+    public void sendMessage(Component message, UUID sender) {
+        LOGGER.info(ChatToLegacyConverter.toLegacy(message));
+    }
+
+    @Override
+    public void sendError(String message) {
+        LOGGER.error(message);
+    }
+
+    @Override
+    public void sendError(String message, UUID sender) {
+        sendError(message);
+    }
+
+    @Override
+    public void sendError(Component message) {
+        LOGGER.error(ChatToLegacyConverter.toLegacy(message));
+    }
+
+    @Override
+    public void sendError(Component message, UUID sender) {
+        sendError(message);
     }
 
     @Override

--- a/server/src/main/java/org/loomdev/loom/util/ChatToLegacyConverter.java
+++ b/server/src/main/java/org/loomdev/loom/util/ChatToLegacyConverter.java
@@ -2,6 +2,7 @@ package org.loomdev.loom.util;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Streams;
+import org.loomdev.loom.util.transformer.TextTransformer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
@@ -77,6 +78,18 @@ public class ChatToLegacyConverter {
         }
 
         return result.toString();
+    }
+
+    /**
+     * Converts a text component to a legacy string
+     * with colors replaced with their legacy codes
+     * (§ followed by a number or letter).
+     *
+     * @return The legacy string.
+     * @see https://minecraft.gamepedia.com/Formatting_codes
+     */
+    public static String toLegacy(net.kyori.adventure.text.Component component) {
+        return toLegacy(TextTransformer.toMinecraft(component));
     }
 
     private static Stream<Component> stream(Component component) {

--- a/server/src/main/java/org/loomdev/loom/util/ChatToLegacyConverter.java
+++ b/server/src/main/java/org/loomdev/loom/util/ChatToLegacyConverter.java
@@ -80,18 +80,6 @@ public class ChatToLegacyConverter {
         return result.toString();
     }
 
-    /**
-     * Converts a text component to a legacy string
-     * with colors replaced with their legacy codes
-     * (§ followed by a number or letter).
-     *
-     * @return The legacy string.
-     * @see https://minecraft.gamepedia.com/Formatting_codes
-     */
-    public static String toLegacy(net.kyori.adventure.text.Component component) {
-        return toLegacy(TextTransformer.toMinecraft(component));
-    }
-
     private static Stream<Component> stream(Component component) {
         return Streams.concat(Stream.of(component), component.getSiblings().stream().flatMap(ChatToLegacyConverter::stream));
     }


### PR DESCRIPTION
Adds a few message sending methods.
It was going to add a argument called `broadcast`, to broadcast a message to all online ops like this: _[player: Successfully destroyed the whole server (you shouldn't have given me OP)]_, to make it easier for plugins to replicate that vanilla feature, but due to the way that command sources currently work, it is not possible to get their names (unless the implementation is changed to use CommandSourceStack instead of CommandSource).

I also accidentally noticed that adventure API already includes chat colours, in [NamedTextColor](https://github.com/KyoriPowered/adventure/blob/7687e72f335571c7c717eac158f9996d2a4eff34/api/src/main/java/net/kyori/adventure/text/format/NamedTextColor.java), so [ChatColor](https://github.com/LoomDev/Loom/blob/2d57f8124c251ba7cd8d0c043cb6185759830c7e/api/src/main/java/org/loomdev/api/util/ChatColor.java) is not needed.

This is the code for broadcasting a message (if it is ever needed):
```java
private void broadcast(@NotNull Component message) {
    Component broadcastMessage = Component.translatable()
            .key("chat.type.admin")
            .args(Component.text(getName() /* TODO */), message)
            .color(ChatColor.GRAY)
            .decorate(TextDecoration.ITALIC);
    Loom.getPlayerManager().getPlayers().forEach((player) -> {
        if (!player.equals(CommandSourceImpl.this)) {
            player.sendMessage(broadcastMessage);
        }
    });
}
```