### PR TITLE
Fix 8 small bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,10 @@ local.properties
 
 # Uncomment this line if you wish to ignore the project description file.
 # Typically, this file would be tracked if it contains build/dependency configurations:
-#.project
+.project
+
+# Eclipse classpath files
+.classpath
 
 ### Eclipse Patch ###
 # Spring Boot Tooling

--- a/server/patches/server/level/ServerPlayer.patch
+++ b/server/patches/server/level/ServerPlayer.patch
@@ -1,14 +1,32 @@
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
-@@ -137,6 +137,7 @@
+@@ -137,6 +137,8 @@
  
  public class ServerPlayer extends Player implements ContainerListener {
  
 +    public java.util.OptionalInt viewDistance = java.util.OptionalInt.empty(); // Loom
++    public Component tabListName = null; // Loom
      private static final Logger LOGGER = LogManager.getLogger();
      public ServerGamePacketListenerImpl connection;
      public final MinecraftServer server;
-@@ -306,7 +307,7 @@
+@@ -192,6 +194,16 @@
+         this.textFilter = minecraftserver.createTextFilterForPlayer(this);
+     }
+ 
++    // Loom start
++    public void updateTabListName() {
++        for (ServerPlayer player : level.getServer().getPlayerList().getPlayers()) {
++            player.connection.send(new net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket(
++                    net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME,
++                    this));
++        }
++    }
++    // Loom end
++
+     private void fudgeSpawnLocation(ServerLevel serverlevel) {
+         BlockPos blockpos = serverlevel.getSharedSpawnPos();
+ 
+@@ -306,7 +318,7 @@
              compoundtag.putInt("SpawnZ", this.respawnPosition.getZ());
              compoundtag.putBoolean("SpawnForced", this.respawnForced);
              compoundtag.putFloat("SpawnAngle", this.respawnAngle);
@@ -17,7 +35,7 @@
              Logger logger = ServerPlayer.LOGGER;
  
              logger.getClass();
-@@ -1245,6 +1246,7 @@
+@@ -1245,6 +1257,7 @@
          this.canChatColor = serverboundclientinformationpacket.getChatColors();
          this.getEntityData().set(ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION, (byte) serverboundclientinformationpacket.getModelCustomisation());
          this.getEntityData().set(ServerPlayer.DATA_PLAYER_MAIN_HAND, (byte) (serverboundclientinformationpacket.getMainHand() == HumanoidArm.LEFT ? 0 : 1));
@@ -25,3 +43,12 @@
      }
  
      public ChatVisiblity getChatVisibility() {
+@@ -1331,7 +1344,7 @@
+ 
+     @Nullable
+     public Component getTabListDisplayName() {
+-        return null;
++        return tabListName;
+     }
+ 
+     public void swing(InteractionHand interactionhand) {

--- a/server/patches/server/level/ServerPlayer.patch
+++ b/server/patches/server/level/ServerPlayer.patch
@@ -1,32 +1,14 @@
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
-@@ -137,6 +137,8 @@
+@@ -137,6 +137,7 @@
  
  public class ServerPlayer extends Player implements ContainerListener {
  
 +    public java.util.OptionalInt viewDistance = java.util.OptionalInt.empty(); // Loom
-+    public Component tabListName = null; // Loom
      private static final Logger LOGGER = LogManager.getLogger();
      public ServerGamePacketListenerImpl connection;
      public final MinecraftServer server;
-@@ -192,6 +194,16 @@
-         this.textFilter = minecraftserver.createTextFilterForPlayer(this);
-     }
- 
-+    // Loom start
-+    public void updateTabListName() {
-+        for (ServerPlayer player : level.getServer().getPlayerList().getPlayers()) {
-+            player.connection.send(new net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket(
-+                    net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME,
-+                    this));
-+        }
-+    }
-+    // Loom end
-+
-     private void fudgeSpawnLocation(ServerLevel serverlevel) {
-         BlockPos blockpos = serverlevel.getSharedSpawnPos();
- 
-@@ -306,7 +318,7 @@
+@@ -306,7 +307,7 @@
              compoundtag.putInt("SpawnZ", this.respawnPosition.getZ());
              compoundtag.putBoolean("SpawnForced", this.respawnForced);
              compoundtag.putFloat("SpawnAngle", this.respawnAngle);
@@ -35,7 +17,7 @@
              Logger logger = ServerPlayer.LOGGER;
  
              logger.getClass();
-@@ -1245,6 +1257,7 @@
+@@ -1245,6 +1246,7 @@
          this.canChatColor = serverboundclientinformationpacket.getChatColors();
          this.getEntityData().set(ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION, (byte) serverboundclientinformationpacket.getModelCustomisation());
          this.getEntityData().set(ServerPlayer.DATA_PLAYER_MAIN_HAND, (byte) (serverboundclientinformationpacket.getMainHand() == HumanoidArm.LEFT ? 0 : 1));
@@ -43,12 +25,12 @@
      }
  
      public ChatVisiblity getChatVisibility() {
-@@ -1331,7 +1344,7 @@
+@@ -1331,7 +1333,7 @@
  
      @Nullable
      public Component getTabListDisplayName() {
 -        return null;
-+        return tabListName;
++        return ((org.loomdev.api.entity.player.Player) getLoomEntity()).getTabListName().map(org.loomdev.loom.util.transformer.TextTransformer::toMinecraft).orElse(null);
      }
  
      public void swing(InteractionHand interactionhand) {

--- a/server/src/main/java/org/loomdev/loom/Loom.java
+++ b/server/src/main/java/org/loomdev/loom/Loom.java
@@ -8,6 +8,7 @@ import org.loomdev.api.ApiVersion;
 import org.loomdev.api.plugin.PluginMetadata;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -92,6 +93,15 @@ public class Loom {
             options = parser.parse(args);
         } catch (joptsimple.OptionException ex) {
             System.err.println(ex.getLocalizedMessage());
+        }
+
+        if (options == null || options.has("?")) {
+            try {
+                parser.printHelpOn(System.out);
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+            System.exit(1);
         }
 
         System.out.println("Starting Minecraft server...");

--- a/server/src/main/java/org/loomdev/loom/Loom.java
+++ b/server/src/main/java/org/loomdev/loom/Loom.java
@@ -11,8 +11,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class Loom {
 
@@ -93,7 +91,7 @@ public class Loom {
         try {
             options = parser.parse(args);
         } catch (joptsimple.OptionException ex) {
-            Logger.getLogger(Main.class.getName()).log(Level.SEVERE, ex.getLocalizedMessage());
+            System.err.println(ex.getLocalizedMessage());
         }
 
         System.out.println("Starting Minecraft server...");

--- a/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
+++ b/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
@@ -9,6 +9,7 @@ import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
 import net.minecraft.network.protocol.game.ClientboundSetTitlesPacket;
 import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
 import net.minecraft.network.protocol.game.ClientboundTabListPacket;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundSource;
@@ -37,6 +38,7 @@ import java.util.UUID;
 
 public class PlayerImpl extends LivingEntityImpl implements Player {
 
+    private Component tabListName;
     private Component tabListHeader;
     private Component tabListFooter;
 
@@ -174,13 +176,13 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
     @Override
     @NotNull
     public Optional<Component> getTabListName() {
-        return Optional.ofNullable(TextTransformer.toLoom(getMinecraftEntity().tabListName));
+        return Optional.ofNullable(tabListName);
     }
 
     @Override
     public void setTabListName(@NotNull Component name) {
-        getMinecraftEntity().tabListName = TextTransformer.toMinecraft(name);
-        getMinecraftEntity().updateTabListName();
+        tabListName = name;
+        updateTabListName();
     }
 
     @Override
@@ -212,6 +214,14 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
                 TextTransformer.toMinecraft(tabListHeader),
                 TextTransformer.toMinecraft(tabListFooter)
         ));
+    }
+
+    private void updateTabListName() {
+        for (ServerPlayer player : getMinecraftEntity().level.getServer().getPlayerList().getPlayers()) {
+            player.connection.send(new ClientboundPlayerInfoPacket(
+                    ClientboundPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME,
+                    getMinecraftEntity()));
+        }
     }
 
     @Override

--- a/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
+++ b/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 
 public class PlayerImpl extends LivingEntityImpl implements Player {
 
-    private Component tabListName;
     private Component tabListHeader;
     private Component tabListFooter;
 
@@ -159,7 +158,7 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
     @Override
     @NotNull
     public Optional<InetSocketAddress> getRemoteAddress() {
-        if (isConnected()) {
+        if (!isConnected()) {
             return Optional.empty();
         }
 
@@ -175,12 +174,13 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
     @Override
     @NotNull
     public Optional<Component> getTabListName() {
-        return Optional.ofNullable(tabListName);
+        return Optional.ofNullable(TextTransformer.toLoom(getMinecraftEntity().tabListName));
     }
 
     @Override
     public void setTabListName(@NotNull Component name) {
-        this.tabListName = name;
+        getMinecraftEntity().tabListName = TextTransformer.toMinecraft(name);
+        getMinecraftEntity().updateTabListName();
     }
 
     @Override
@@ -192,7 +192,7 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
     @Override
     public void setTabListHeader(@NotNull Component header) {
         this.tabListHeader = header;
-        updateTablist();
+        updateTabList();
     }
 
     @Override
@@ -204,10 +204,10 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
     @Override
     public void setTabListFooter(@NotNull Component footer) {
         tabListFooter = footer;
-        updateTablist();
+        updateTabList();
     }
 
-    private void updateTablist() {
+    private void updateTabList() {
         getMinecraftEntity().connection.send(new ClientboundTabListPacket(
                 TextTransformer.toMinecraft(tabListHeader),
                 TextTransformer.toMinecraft(tabListFooter)

--- a/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
+++ b/server/src/main/java/org/loomdev/loom/entity/player/PlayerImpl.java
@@ -182,7 +182,12 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
     @Override
     public void setTabListName(@NotNull Component name) {
         tabListName = name;
-        updateTabListName();
+        ClientboundPlayerInfoPacket updatePacket = new ClientboundPlayerInfoPacket(
+                ClientboundPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME,
+                getMinecraftEntity());
+        for (ServerPlayer player : getMinecraftEntity().level.getServer().getPlayerList().getPlayers()) {
+            player.connection.send(updatePacket);
+        }
     }
 
     @Override
@@ -214,14 +219,6 @@ public class PlayerImpl extends LivingEntityImpl implements Player {
                 TextTransformer.toMinecraft(tabListHeader),
                 TextTransformer.toMinecraft(tabListFooter)
         ));
-    }
-
-    private void updateTabListName() {
-        for (ServerPlayer player : getMinecraftEntity().level.getServer().getPlayerList().getPlayers()) {
-            player.connection.send(new ClientboundPlayerInfoPacket(
-                    ClientboundPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME,
-                    getMinecraftEntity()));
-        }
     }
 
     @Override


### PR DESCRIPTION
Fixes 8 small bugs:

- setTabListName does nothing except change a previously useless field.
- getRemoteAddress returns an empty optional when the player is online.
- Small method naming inconsistency.
- .project and .classpath files aren't in .gitignore, meaning that Eclipse users (like me) can end up committing .project and .classpath files which are only necessary in projects that don't use Maven, Gradle or any other build tool.
- The server main class uses a logger is not properly formatted (replaced with System.err for consistency with the "Starting Minecraft server..." message).
- Component converted to Stream, instead of being converted directly to a List.
- ChatToLegacyConverter not working properly (I had too look at CraftBukkit's source to work it out).
- Help flag does not work correctly.

Also, just a suggestion, maybe it would be good to switch back to [Yarn](https://github.com/FabricMC/yarn) mappings, to avoid copyright infringement inside the patch (they are completely open source).

Pros of Yarn mappings:
- Very permissive license.
- Includes Javadoc (may require some tinkering, as Spigot's fork of Fernflower does not support Javadoc) and parameter names (built into tiny remapper).
- Updated quickly.
- Quite often has more logical names (official mappings have a method called "fudgeSpawnLocation" inside ServerPlayer, spell "collision" like "collission" and there are probably quite a lot more illogical names I missed).
- Simpler names (in some cases) (e.g. net.minecraft.world.level.Blocks -> net.minecraft.block.Blocks and net.minecraft.server.level.ServerPlayer -> net.minecraft.entity.player.ServerPlayer).
- No conversion required, as they are already converted at https://maven.fabricmc.net/net/fabricmc/yarn/VERSION/yarn-VERSION-mergedv2.jar (I personally wouldn't recommend using a submodule and then building the mapped jar with Gradle as that's just slow compared to downloading the converted version and running tiny remapper).
- Quicker to download as they use a fairly compact format.

Pros of Mojang mappings:
 - Updated ever quicker.
 - No unmapped names.
 - Decompiled code more similar to original code.
 - Simple versioning system.
 
Don't feel under pressure to review this if it's too late is your time zone.