### PR TITLE
Split chat event into message and format (and fix plugins command)

### DIFF
--- a/api/src/main/java/org/loomdev/api/event/Subscribe.java
+++ b/api/src/main/java/org/loomdev/api/event/Subscribe.java
@@ -14,6 +14,6 @@ public @interface Subscribe {
 
     EventOrder order() default EventOrder.NORMAL;
 
-    // TODO Event uses getCanceled
+    // TODO Cancelled -> Canceled
     boolean ignoreCancelled() default false;
 }

--- a/api/src/main/java/org/loomdev/api/event/entity/PlayerEvent.java
+++ b/api/src/main/java/org/loomdev/api/event/entity/PlayerEvent.java
@@ -13,10 +13,56 @@ public interface PlayerEvent extends Event {
 
     interface Chat extends PlayerEvent, Cancelable {
 
+        /**
+         * Gets the chat message's content.
+         *
+         * @return The content.
+         */
         @NotNull
         Component getMessage();
 
-        void setMessage(@NotNull Component component);
+        /**
+         * Sets the chat message's content.
+         * @param message The content.
+         */
+        void setMessage(@NotNull Component message);
+
+        /**
+         * Gets the chat message's format.
+         *
+         * <p>Example usage:</p>
+         * <p><code>Component formattedMessage = event.getFormat().apply(event.getPlayer().getDisplayName(), event.getMessage());</code></p>
+         *
+         * @return The format.
+         */
+        @NotNull
+        Format getFormat();
+
+        /**
+         * Sets the chat message's format.
+         *
+         * <p>Example usage:</p>
+         * <p><code>event.setFormat((name, message) -> Component.text().append(name).append(Component.text(": ")).append(message).build());</code></p>
+         *
+         * @param format The format.
+         */
+        void setFormat(@NotNull Format format);
+
+        /**
+         * Represents a chat message format.
+         */
+        @FunctionalInterface
+        interface Format {
+
+            /**
+             * Formats a chat message.
+             *
+             * @param name The display name of the sender.
+             * @param message The sent message.
+             * @return The formatted message.
+             */
+            public Component apply(Component name, Component message);
+        }
     }
 
     interface Join extends PlayerEvent {

--- a/api/src/main/java/org/loomdev/api/event/entity/PlayerEvent.java
+++ b/api/src/main/java/org/loomdev/api/event/entity/PlayerEvent.java
@@ -42,7 +42,7 @@ public interface PlayerEvent extends Event {
          * Sets the chat message's format.
          *
          * <p>Example usage:</p>
-         * <p><code>event.setFormat((name, message) -> Component.text().append(name).append(Component.text(": ")).append(message).build());</code></p>
+         * <p><code>event.setFormat((name, message) -&gt; Component.text().append(name).append(Component.text(": ")).append(message).build());</code></p>
          *
          * @param format The format.
          */

--- a/server/patches/server/network/ServerGamePacketListenerImpl.patch
+++ b/server/patches/server/network/ServerGamePacketListenerImpl.patch
@@ -44,15 +44,18 @@
          this.player.disconnect();
          this.server.getPlayerList().remove(this.player);
          TextFilter textfilter = this.player.getTextFilter();
-@@ -1193,7 +1199,13 @@
+@@ -1191,9 +1197,15 @@
+             if (s.startsWith("/")) {
+                 this.handleCommand(s);
              } else {
-                 TranslatableComponent translatablecomponent = new TranslatableComponent("chat.type.text", new Object[]{this.player.getDisplayName(), s});
+-                TranslatableComponent translatablecomponent = new TranslatableComponent("chat.type.text", new Object[]{this.player.getDisplayName(), s});
++                // Loom start :: fire PlayerEvent.Chat
++                // TranslatableComponent translatablecomponent = new TranslatableComponent("chat.type.text", new Object[]{this.player.getDisplayName(), s});
  
 -                this.server.getPlayerList().broadcastMessage(translatablecomponent, ChatType.CHAT, this.player.getUUID());
-+                // Loom start :: fire PlayerEvent.Chat
-+                org.loomdev.loom.event.LoomEventDispatcher.fireAsync(new org.loomdev.loom.event.entity.PlayerEventImpl.ChatImpl(player, translatablecomponent)).thenAccept(event -> {
++                org.loomdev.loom.event.LoomEventDispatcher.fireAsync(new org.loomdev.loom.event.entity.PlayerEventImpl.ChatImpl(player, net.kyori.adventure.text.Component.text(s))).thenAccept(event -> {
 +                    if (event.isCanceled() || event.getMessage().toString().length() == 0) return;
-+                    var message = org.loomdev.loom.util.transformer.TextTransformer.toMinecraft(event.getMessage());
++                    var message = org.loomdev.loom.util.transformer.TextTransformer.toMinecraft(event.getFormat().apply(player.getLoomEntity().getDisplayName(), event.getMessage()));
 +                    this.server.getPlayerList().broadcastMessage(message, ChatType.CHAT, this.player.getUUID());
 +                });
 +                // Loom end

--- a/server/src/main/java/org/loomdev/loom/command/loom/PluginsCommand.java
+++ b/server/src/main/java/org/loomdev/loom/command/loom/PluginsCommand.java
@@ -38,7 +38,7 @@ public class PluginsCommand extends Command {
             return;
         }
 
-        if (source.hasPermission("loom.command.plugins.admin")) {
+        if (!source.hasPermission("loom.command.plugins.admin")) {
             source.sendMessage(Component.text("Insufficient permissions!").color(ChatColor.RED));
             return;
         }
@@ -97,7 +97,7 @@ public class PluginsCommand extends Command {
                 .filter(plugin -> full || Loom.getPluginManager().isEnabled(plugin.getId()))
                 .forEach(plugin -> plugins.put(plugin.getNameOrId(), plugin));
 
-        Component builder = Component.empty()
+        TextComponent.Builder builder = Component.text()
                 .append(Component.text("Plugins (" + plugins.size() + "): ").color(ChatColor.WHITE));
 
         int index = 0;
@@ -106,9 +106,9 @@ public class PluginsCommand extends Command {
                 builder.append(Component.text(", ").color(ChatColor.WHITE));
             }
 
-            Component pluginBuilder = Component.empty();
+            TextComponent.Builder pluginBuilder = Component.text();
             PluginMetadata metadata = entry.getValue();
-            Component hoverBuilder = Component.empty();
+            TextComponent.Builder hoverBuilder = Component.text();
 
             if (full) {
                 hoverBuilder.append(Component.text("Id: ").color(ChatColor.WHITE)
@@ -156,7 +156,7 @@ public class PluginsCommand extends Command {
             builder.append(pluginBuilder);
         }
 
-        source.sendMessage(builder);
+        source.sendMessage(builder.build());
     }
 
     private TextComponent getHelpText() {

--- a/server/src/main/java/org/loomdev/loom/event/entity/PlayerEventImpl.java
+++ b/server/src/main/java/org/loomdev/loom/event/entity/PlayerEventImpl.java
@@ -26,10 +26,12 @@ public class PlayerEventImpl extends EventImpl implements PlayerEvent {
 
         private Component message;
         private boolean canceled;
+        private Format format;
 
-        public ChatImpl(ServerPlayer player, net.minecraft.network.chat.Component message) {
+        public ChatImpl(ServerPlayer player, Component message) {
             super((Player) player.getLoomEntity());
-            this.message = TextTransformer.toLoom(message);
+            this.message = message;
+            this.format = (name, processedMessage) -> Component.translatable("chat.type.text").args(name, processedMessage);
         }
 
         @Override
@@ -41,6 +43,17 @@ public class PlayerEventImpl extends EventImpl implements PlayerEvent {
         @Override
         public void setMessage(@NotNull Component component) {
             this.message = component;
+        }
+
+        @Override
+        @NotNull
+        public Format getFormat() {
+            return format;
+        }
+
+        @Override
+        public void setFormat(@NotNull Format format) {
+            this.format = format;
         }
 
         @Override


### PR DESCRIPTION
Splits chat events into the message and the format. It also fixes a few big bugs in the plugins command and adds some Javadoc to reduce ambiguity.
Previously it would be pretty hard for a plugin to find out the content of a message.